### PR TITLE
Fix EntityEnderman's held block when the ID is above 32767

### DIFF
--- a/src/main/java/com/cleanroommc/hadenoughids/core/mixins/EntityEndermanMixin.java
+++ b/src/main/java/com/cleanroommc/hadenoughids/core/mixins/EntityEndermanMixin.java
@@ -1,0 +1,27 @@
+package com.cleanroommc.hadenoughids.core.mixins;
+
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.monster.EntityEnderman;
+import net.minecraft.nbt.NBTTagCompound;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import javax.annotation.Nullable;
+
+@Mixin(EntityEnderman.class)
+public abstract class EntityEndermanMixin {
+    @Shadow @Nullable public abstract IBlockState getHeldBlockState();
+
+    /**
+     * @reason Make Endermen always save their carried block as a string to avoid issues with IDs above 32767.
+     */
+    @Redirect(method = "writeEntityToNBT", at = @At(value = "INVOKE", target = "Lnet/minecraft/nbt/NBTTagCompound;setShort(Ljava/lang/String;S)V", ordinal = 0))
+    private void redirectCarried(NBTTagCompound instance, String key, short value) {
+        if(key.equals("carried")) {
+            instance.setString("carried", this.getHeldBlockState().getBlock().getRegistryName().toString());
+        } else
+            instance.setShort(key, value);
+    }
+}

--- a/src/main/resources/mixins.hadenoughids.json
+++ b/src/main/resources/mixins.hadenoughids.json
@@ -6,6 +6,7 @@
   "compatibilityLevel": "JAVA_8",
   "mixins": [
     "BlockMixin",
+    "EntityEndermanMixin",
     "ForgeRegistryAccessor",
     "RegistryManagerAccessor",
     "StatListMixin",


### PR DESCRIPTION
Due to vanilla storing the block ID as a short in the NBT, endermen cannot carry any blocks with an ID above 32767 (`Short.MAX_VALUE`). This addresses that issue by making endermen always store their block using the registry name instead of the ID directly. Vanilla already supports reading this format but does not write it that way by default.